### PR TITLE
Avoid a deprecation warning in FoundationXML when initializing XMLElement instances by initializing them as comments

### DIFF
--- a/Sources/OrderedPlistEncoder/Container/KeyedOrderedPlistEncodingContainer.swift
+++ b/Sources/OrderedPlistEncoder/Container/KeyedOrderedPlistEncodingContainer.swift
@@ -16,7 +16,7 @@ struct KeyedOrderedPlistEncodingContainer<Key>: KeyedEncodingContainerProtocol w
 
     private mutating func addChildElement(forKey key: Key) -> XMLElement {
         // TODO: Add check for duplicate keys (should we throw an EncodingError?)
-        let childElement: XMLElement = .init()
+        let childElement = XMLElement(kind: .comment)
         element.addChild(XMLElement(name: "key", stringValue: key.stringValue))
         element.addChild(childElement)
         return childElement

--- a/Sources/OrderedPlistEncoder/Container/UnkeyedOrderedPlistEncodingContainer.swift
+++ b/Sources/OrderedPlistEncoder/Container/UnkeyedOrderedPlistEncodingContainer.swift
@@ -16,7 +16,7 @@ struct UnkeyedOrderedPlistEncodingContainer: UnkeyedEncodingContainer {
     }
 
     private mutating func addItemElement() -> XMLElement {
-        let itemElement: XMLElement = .init()
+        let itemElement = XMLElement(kind: .comment)
         element.addChild(itemElement)
         count += 1
         return itemElement

--- a/Sources/OrderedPlistEncoder/OrderedPlistEncoderImpl.swift
+++ b/Sources/OrderedPlistEncoder/OrderedPlistEncoderImpl.swift
@@ -14,7 +14,7 @@ struct OrderedPlistEncoderImpl: Encoder {
 
     private(set) var element: XMLElement
 
-    init(element: XMLElement = .init(), codingPath: [any CodingKey] = []) {
+    init(element: XMLElement = XMLElement(kind: .comment), codingPath: [any CodingKey] = []) {
         self.element = element
         self.codingPath = codingPath
     }


### PR DESCRIPTION
When initialized via the default initializer, the swift-foundation version of XMLElement will initialize each instance as ".invalid" via the XMLNode implementation that it inherits from.

This will also print out a deprecation warning when compiling that discourages all uses of the default XMLElement initializer, as seen in https://github.com/apple/swift-corelibs-foundation/blob/main/Sources/FoundationXML/XMLNode.swift#L108

To mitigate this, this change initializes all of the XMLElement instances in this project as ".comment" instances. This does not change the output of XMLDocument in system Foundation or the open source swift-foundation as far as swift-ordered-plist-encoder's implementation is concerned, and it successfully suppresses the warning when compling.